### PR TITLE
Homework 5.2 Библиотека Spring-JDBC - работа с ключами, транзакции, адаптеры

### DIFF
--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/auth/AuthUserDBSpringChainedXaClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/auth/AuthUserDBSpringChainedXaClient.java
@@ -1,0 +1,53 @@
+package guru.qa.niffler.service.auth;
+
+import guru.qa.niffler.config.Config;
+import guru.qa.niffler.data.dao.auth.AuthUserDAO;
+import guru.qa.niffler.data.dao.auth.AuthorityDAO;
+import guru.qa.niffler.data.dao.auth.impl.spring.AuthUserDAOSpringJdbc;
+import guru.qa.niffler.data.dao.auth.impl.spring.AuthorityDAOSpringJdbc;
+import guru.qa.niffler.data.entity.auth.AuthUserEntity;
+import guru.qa.niffler.data.entity.auth.AuthorityEntity;
+import guru.qa.niffler.data.template.JdbcTransactionTemplate;
+import org.springframework.data.transaction.ChainedTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static guru.qa.niffler.data.template.DataSources.dataSource;
+
+public class AuthUserDBSpringChainedXaClient {
+    private static final Config CFG = Config.getInstance();
+
+    private final AuthUserDAO authUserDAO;
+    private final AuthorityDAO authorityDAO;
+    private final TransactionTemplate chainedTemplate;
+
+    public AuthUserDBSpringChainedXaClient() {
+        authUserDAO = new AuthUserDAOSpringJdbc();
+        authorityDAO = new AuthorityDAOSpringJdbc();
+        chainedTemplate = new TransactionTemplate(
+                new ChainedTransactionManager(
+                        new JdbcTransactionManager(dataSource(CFG.authJdbcUrl()))
+                )
+        );
+    }
+
+    public Optional<AuthUserEntity> findUserById(UUID id) {
+        return chainedTemplate.execute(
+                con -> authUserDAO.findById(id));
+    }
+
+    public Optional<AuthUserEntity> findUserByUsername(String username) {
+        return chainedTemplate.execute(
+                con -> authUserDAO.findByUsername(username));
+    }
+
+    public List<AuthorityEntity> findAuthorityByUserId(AuthUserEntity authUser) {
+        return chainedTemplate.execute(
+                con -> authorityDAO.findByAuthUserId(authUser));
+    }
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/userdata/UdDBSpringChainedXaClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/userdata/UdDBSpringChainedXaClient.java
@@ -1,0 +1,108 @@
+package guru.qa.niffler.service.userdata;
+
+import guru.qa.niffler.config.Config;
+import guru.qa.niffler.data.dao.auth.AuthUserDAO;
+import guru.qa.niffler.data.dao.auth.AuthorityDAO;
+import guru.qa.niffler.data.dao.auth.impl.spring.AuthUserDAOSpringJdbc;
+import guru.qa.niffler.data.dao.auth.impl.spring.AuthorityDAOSpringJdbc;
+import guru.qa.niffler.data.dao.userdata.UserdataUserDAO;
+import guru.qa.niffler.data.dao.userdata.impl.UserdataUserDAOSpringJdbc;
+import guru.qa.niffler.data.entity.auth.AuthUserEntity;
+import guru.qa.niffler.data.entity.auth.Authority;
+import guru.qa.niffler.data.entity.auth.AuthorityEntity;
+import guru.qa.niffler.data.entity.userdata.UserdataUserEntity;
+import guru.qa.niffler.model.UserdataUserJson;
+import org.springframework.data.transaction.ChainedTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import static guru.qa.niffler.data.template.DataSources.dataSource;
+
+public class UdDBSpringChainedXaClient {
+    private static final Config CFG = Config.getInstance();
+    private static final PasswordEncoder pe = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+    private final UserdataUserDAO udUserDAO;
+    private final AuthUserDAO authUserDAO;
+    private final AuthorityDAO authorityDAO;
+    private final TransactionTemplate chainedTemplate;
+
+    public UdDBSpringChainedXaClient() {
+        udUserDAO = new UserdataUserDAOSpringJdbc();
+        authUserDAO = new AuthUserDAOSpringJdbc();
+        authorityDAO = new AuthorityDAOSpringJdbc();
+        chainedTemplate = new TransactionTemplate(
+                new ChainedTransactionManager(
+                        new JdbcTransactionManager(dataSource(CFG.authJdbcUrl())),
+                        new JdbcTransactionManager(dataSource(CFG.userdataJdbcUrl()))
+                )
+        );
+    }
+
+    public UserdataUserJson create(UserdataUserJson user) {
+        chainedTemplate.setIsolationLevel(Connection.TRANSACTION_READ_UNCOMMITTED);
+        return chainedTemplate.execute(connection -> {
+                    AuthUserEntity authUser = new AuthUserEntity();
+                    authUser.setUsername(user.username());
+                    authUser.setPassword(pe.encode("12345"));
+                    authUser.setEnabled(true);
+                    authUser.setAccountNonExpired(true);
+                    authUser.setAccountNonLocked(true);
+                    authUser.setCredentialsNonExpired(true);
+                    authUserDAO.create(authUser);
+                    authorityDAO.create(
+                            Arrays.stream(Authority.values())
+                                    .map(a -> {
+                                                AuthorityEntity ae = new AuthorityEntity();
+                                                ae.setUserId(authUser.getId());
+                                                ae.setAuthority(a);
+                                                return ae;
+                                            }
+                                    ).toArray(AuthorityEntity[]::new));
+                    //тут падение транзакции и проверка rollback
+                    if (user.username().equals("failUser")) {
+                        throw new RuntimeException("Искусственная ошибка в authUserDAO");
+                    }
+                    return UserdataUserJson.fromEntity(udUserDAO
+                            .create(
+                                    UserdataUserEntity.fromJson(user)), null);
+                }
+        );
+    }
+
+    public Optional<UserdataUserJson> findById(UUID id) {
+        chainedTemplate.setIsolationLevel(Connection.TRANSACTION_READ_COMMITTED);
+        return chainedTemplate.execute(connection ->
+                udUserDAO.findById(id)
+                        .map(x ->
+                                UserdataUserJson.fromEntity(x, null)));
+    }
+
+    public Optional<UserdataUserJson> findByUsername(String username) {
+        chainedTemplate.setIsolationLevel(Connection.TRANSACTION_READ_COMMITTED);
+        return chainedTemplate.execute(connection ->
+                udUserDAO.findByUsername(username)
+                        .map(x -> UserdataUserJson.fromEntity(x, null)));
+    }
+
+    public void delete(UserdataUserJson userdataUserJson) {
+        chainedTemplate.setIsolationLevel(Connection.TRANSACTION_SERIALIZABLE);
+        chainedTemplate.executeWithoutResult(connection -> {
+            udUserDAO.delete(
+                    UserdataUserEntity.fromJson(userdataUserJson));
+            authUserDAO.findByUsername(userdataUserJson.username())
+                    .ifPresent(entity -> {
+                        authorityDAO.delete(entity);
+                        authUserDAO.deleteByUsername(entity);
+                    });
+        });
+    }
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/ChainedXaTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/ChainedXaTest.java
@@ -1,0 +1,57 @@
+package guru.qa.niffler.test.web;
+
+import guru.qa.niffler.data.entity.auth.AuthUserEntity;
+import guru.qa.niffler.data.entity.auth.AuthorityEntity;
+import guru.qa.niffler.model.CurrencyValues;
+import guru.qa.niffler.model.UserdataUserJson;
+import guru.qa.niffler.service.auth.AuthUserDBSpringChainedXaClient;
+import guru.qa.niffler.service.auth.AuthUserDBSpringClient;
+import guru.qa.niffler.service.userdata.UdDBSpringChainedXaClient;
+import guru.qa.niffler.service.userdata.UserdataDBSpringClient;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static guru.qa.niffler.util.RandomDataUtils.randomName;
+import static guru.qa.niffler.util.RandomDataUtils.randomSurname;
+
+@Slf4j
+public class ChainedXaTest {
+
+    @Test
+    void checkTransactionByUserTest() {
+        UdDBSpringChainedXaClient userdataDBClient = new UdDBSpringChainedXaClient();
+        AuthUserDBSpringChainedXaClient authUserDBClient = new AuthUserDBSpringChainedXaClient();
+        String username = "chainedTransac";
+        userdataDBClient.findByUsername(username)
+                .ifPresent(userJson -> {
+                    userdataDBClient.delete(userJson);
+                    log.info("DELETED USER");
+                });
+        // транзакция упадет из-за явного вызова ошибки в коде в методе create
+        userdataDBClient.create(
+                new UserdataUserJson(
+                        null,
+                        username,
+                        randomSurname(),
+                        randomSurname(),
+                        randomName(),
+                        CurrencyValues.RUB,
+                        null,
+                        null,
+                        null
+                ));
+        log.info("EXPECT NOT CREATED USER");
+        UserdataUserJson udUser = userdataDBClient.findByUsername(username).orElse(null);
+        Assertions.assertNull(udUser, "Юзер %s был создан".formatted(udUser));
+        log.info("EXPECT CREATED AUTH_USER");
+        AuthUserEntity authUserEntity = authUserDBClient.findUserByUsername(username).orElse(null);
+        Assertions.assertNotNull(authUserEntity, "Юзер авторизации %s не был создан. Транзакция работает хорошо".formatted(authUserEntity));
+        List<AuthorityEntity> authority = authUserDBClient.findAuthorityByUserId(authUserEntity);
+        Assertions.assertTrue(authority.isEmpty(), "авторизация была создана %s".formatted(authority));
+        Assertions.assertEquals(2, authority.size(), "авторизация создана не в полном объеме %d".formatted(authority.size()));
+
+    }
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/JdbcTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/JdbcTest.java
@@ -3,8 +3,8 @@ package guru.qa.niffler.test.web;
 import guru.qa.niffler.data.entity.auth.AuthUserEntity;
 import guru.qa.niffler.model.*;
 import guru.qa.niffler.service.auth.AuthUserDBClient;
+import guru.qa.niffler.service.spend.CategoryDBClient;
 import guru.qa.niffler.service.userdata.UserdataDBClient;
-import guru.qa.niffler.service.spend.CategoryDBSpringClient;
 import guru.qa.niffler.service.spend.SpendDBClient;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -24,6 +24,7 @@ class JdbcTest {
         String categoryName = "top cource";
         String spendDescription = "cool cource";
         SpendDBClient dbSpend = new SpendDBClient();
+        CategoryDBClient categoryDbClient = new CategoryDBClient();
         dbSpend.findByUsernameAndDescription(MAIN_USERNAME, spendDescription)
                 .ifPresent(entity -> {
                     dbSpend.delete(entity);
@@ -52,18 +53,21 @@ class JdbcTest {
                 "Объект %s неправильно создан. В БД такой %s".formatted(newSpendJson, resultSpend));
         Assertions.assertEquals(newSpendJson.category().name(), resultSpend.category().name(),
                 "%s для %s не равны".formatted(newSpendJson.category(), resultSpend.category()));
+        CategoryJson categoryJson = categoryDbClient.findById(newSpendJson.category().id()).get();
+        Assertions.assertEquals(newSpendJson.category(), categoryJson,
+                "объект %s не равен %s".formatted(newSpendJson.category(), categoryJson));
     }
 
     @Test
     void checkCRUDCategoryTest() {
         String categoryName = "Top category";
-        CategoryDBSpringClient dbSpringClient = new CategoryDBSpringClient();
+        CategoryDBClient dbSpringClient = new CategoryDBClient();
         dbSpringClient.findByUsernameAndName(MAIN_USERNAME, categoryName)
                 .ifPresent(category -> {
                     dbSpringClient.delete(category);
                     log.info("CATEGORY DELETED");
                 });
-        CategoryJson newCategoryJson = dbSpringClient.create(
+        CategoryJson newCategoryJson = dbSpringClient.createCategory(
                 new CategoryJson(
                         null,
                         categoryName,
@@ -117,6 +121,42 @@ class JdbcTest {
         Assertions.assertNull(userJson, "Юзер %s не удален".formatted(userJson));
         authUserEntity = authUserDBClient.findUserByUsername(userdataUserJson.username()).orElse(null);
         Assertions.assertNull(authUserEntity, "Юзер авторизации %s был создан".formatted(authUserEntity));
+    }
+
+    @Test
+    void checkTransactionSpendTest() {
+        String categoryName = "top cource transac2";
+        String spendDescription = "cool cource transac";
+        SpendDBClient dbSpend = new SpendDBClient();
+        CategoryDBClient categoryDbClient = new CategoryDBClient();
+        dbSpend.findByUsernameAndDescription(MAIN_USERNAME, spendDescription)
+                .ifPresent(entity -> {
+                    dbSpend.delete(entity);
+                    log.info("SPEND DELETED");
+                });
+        Assertions.assertThrows(RuntimeException.class,
+                () -> dbSpend.create(new SpendJson(
+                        null,
+                        new Date(),
+                        new CategoryJson(null,
+                                categoryName,
+                                MAIN_USERNAME,
+                                true),
+                        null, // падение транзакции
+                        100.0,
+                        spendDescription,
+                        MAIN_USERNAME
+                )));
+        log.info("CHECK NOT SPEND CREATED");
+        SpendJson resultSpend = dbSpend
+                .findByUsernameAndDescription(MAIN_USERNAME, spendDescription).orElse(null);
+        Assertions.assertNull(resultSpend,
+                "объект %s был создан(".formatted(resultSpend));
+        log.info("CHECK NOT CATEGORY CREATED");
+        CategoryJson categoryJson = categoryDbClient
+                .findByUsernameAndName(MAIN_USERNAME, categoryName).orElse(null);
+        Assertions.assertNull(categoryJson,
+                "объект %s был создан(".formatted(categoryJson));
     }
 
     @Test


### PR DESCRIPTION
Основная проблема класса ChainedTransactionManager и причина отказа от его использования состоит в его атомарности. Если в ходе транзакции будет вызвана ошибка, то rollback может не состоятся. В своем коде, в методе create я явно вызываю ошибку после создания AuthUser и AuthorityEntity и перед созданием userdataUser. Затем тестами определяется, что то, что было до вызова ошибки уже находится в БД и rollback не выполнен как нужно и это доказывает, что принцип "Все или ничего" в данном случае не работает